### PR TITLE
基本的なファイルシステム操作API実装 (Issue #12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +137,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +180,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "base64"
@@ -1277,6 +1334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2060,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,7 +2465,12 @@ dependencies = [
 name = "rust-explorer-core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "rust-explorer-utils",
+ "serde",
+ "tempfile",
+ "tokio",
+ "tokio-test",
 ]
 
 [[package]]
@@ -2422,6 +2499,12 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -3039,6 +3122,52 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "toml_datetime"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -6,3 +6,10 @@ description = "Core functionality for rust-explorer"
 
 [dependencies]
 rust-explorer-utils = { path = "../utils" }
+tokio = { version = "1", features = ["fs", "rt", "macros"] }
+serde = { version = "1.0", features = ["derive"] }
+async-trait = "0.1"
+
+[dev-dependencies]
+tempfile = "3.0"
+tokio-test = "0.4"

--- a/crates/core/src/filesystem.rs
+++ b/crates/core/src/filesystem.rs
@@ -1,7 +1,52 @@
 //! ファイルシステム操作
 
 use rust_explorer_utils::AppError;
+use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+use tokio::fs;
+
+/// ファイルタイプ
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum FileType {
+    File,
+    Directory,
+    SymLink,
+    Other,
+}
+
+/// ファイルエントリ
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileEntry {
+    pub name: String,
+    pub path: PathBuf,
+    pub file_type: FileType,
+    pub size: u64,
+    pub modified: Option<SystemTime>,
+}
+
+/// ファイル情報
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileInfo {
+    pub path: PathBuf,
+    pub file_type: FileType,
+    pub size: u64,
+    pub modified: Option<SystemTime>,
+    pub permissions: Option<String>,
+}
+
+/// ファイルシステムAPI トレイト
+#[async_trait::async_trait]
+pub trait FileSystemApi {
+    /// ディレクトリ一覧取得
+    async fn list_directory(&self, path: &Path) -> Result<Vec<FileEntry>, AppError>;
+
+    /// ファイル情報取得
+    async fn get_file_info(&self, path: &Path) -> Result<FileInfo, AppError>;
+
+    /// アクセス可能かチェック
+    fn is_accessible(&self, path: &Path) -> bool;
+}
 
 /// ファイルシステム管理
 pub struct FileSystemManager {
@@ -33,13 +78,144 @@ impl FileSystemManager {
     }
 
     /// ディレクトリの内容を一覧取得（将来の実装）
-    pub fn list_directory<P: AsRef<Path>>(&self, _path: P) -> Result<Vec<PathBuf>, AppError> {
+    pub async fn list_directory_sync<P: AsRef<Path>>(
+        &self,
+        _path: P,
+    ) -> Result<Vec<PathBuf>, AppError> {
         // 将来の実装でディレクトリ内容を返す
         Ok(vec![])
     }
 }
 
+/// ファイルシステムAPI の実装
+#[async_trait::async_trait]
+impl FileSystemApi for FileSystemManager {
+    async fn list_directory(&self, path: &Path) -> Result<Vec<FileEntry>, AppError> {
+        if !path.exists() {
+            return Err(AppError::InvalidPath(path.to_path_buf()));
+        }
+
+        if !path.is_dir() {
+            return Err(AppError::InvalidPath(path.to_path_buf()));
+        }
+
+        let mut entries = Vec::new();
+        let mut dir = fs::read_dir(path)
+            .await
+            .map_err(AppError::FileSystem)?;
+
+        while let Some(entry) = dir
+            .next_entry()
+            .await
+            .map_err(AppError::FileSystem)?
+        {
+            let path = entry.path();
+            let metadata = entry
+                .metadata()
+                .await
+                .map_err(AppError::FileSystem)?;
+
+            let file_type = if metadata.is_dir() {
+                FileType::Directory
+            } else if metadata.is_file() {
+                FileType::File
+            } else if metadata.file_type().is_symlink() {
+                FileType::SymLink
+            } else {
+                FileType::Other
+            };
+
+            let name = entry.file_name().to_string_lossy().to_string();
+            let size = metadata.len();
+            let modified = metadata.modified().ok();
+
+            entries.push(FileEntry {
+                name,
+                path,
+                file_type,
+                size,
+                modified,
+            });
+        }
+
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(entries)
+    }
+
+    async fn get_file_info(&self, path: &Path) -> Result<FileInfo, AppError> {
+        if !path.exists() {
+            return Err(AppError::InvalidPath(path.to_path_buf()));
+        }
+
+        let metadata = fs::metadata(path)
+            .await
+            .map_err(AppError::FileSystem)?;
+
+        let file_type = if metadata.is_dir() {
+            FileType::Directory
+        } else if metadata.is_file() {
+            FileType::File
+        } else if metadata.file_type().is_symlink() {
+            FileType::SymLink
+        } else {
+            FileType::Other
+        };
+
+        let size = metadata.len();
+        let modified = metadata.modified().ok();
+        let permissions = None; // クロスプラットフォーム対応のため簡略化
+
+        Ok(FileInfo {
+            path: path.to_path_buf(),
+            file_type,
+            size,
+            modified,
+            permissions,
+        })
+    }
+
+    fn is_accessible(&self, path: &Path) -> bool {
+        path.exists() && (path.is_file() || path.is_dir())
+    }
+}
+
 impl Default for FileSystemManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// キャッシュ付きファイルシステム管理（将来の実装）
+pub struct CachedFileSystemManager {
+    inner: FileSystemManager,
+    // cache: HashMap<PathBuf, (Vec<FileEntry>, SystemTime)>,
+}
+
+impl CachedFileSystemManager {
+    pub fn new() -> Self {
+        Self {
+            inner: FileSystemManager::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl FileSystemApi for CachedFileSystemManager {
+    async fn list_directory(&self, path: &Path) -> Result<Vec<FileEntry>, AppError> {
+        // 将来的にキャッシュ機能を実装
+        self.inner.list_directory(path).await
+    }
+
+    async fn get_file_info(&self, path: &Path) -> Result<FileInfo, AppError> {
+        self.inner.get_file_info(path).await
+    }
+
+    fn is_accessible(&self, path: &Path) -> bool {
+        self.inner.is_accessible(path)
+    }
+}
+
+impl Default for CachedFileSystemManager {
     fn default() -> Self {
         Self::new()
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,5 +7,10 @@
 pub mod event;
 pub mod filesystem;
 
+#[cfg(test)]
+mod tests;
+
 pub use event::{Event, EventManager};
-pub use filesystem::FileSystemManager;
+pub use filesystem::{
+    CachedFileSystemManager, FileEntry, FileInfo, FileSystemApi, FileSystemManager, FileType,
+};

--- a/crates/core/src/tests/filesystem_tests.rs
+++ b/crates/core/src/tests/filesystem_tests.rs
@@ -1,0 +1,169 @@
+//! ファイルシステムAPIのテスト
+
+use crate::filesystem::{FileSystemApi, FileSystemManager, FileType};
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio;
+
+/// テスト用の一時ディレクトリとファイルを作成
+async fn create_test_structure() -> Result<TempDir, Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let temp_path = temp_dir.path();
+
+    // テストファイルを作成
+    fs::write(temp_path.join("test_file.txt"), "test content")?;
+
+    // テストディレクトリを作成
+    fs::create_dir(temp_path.join("test_dir"))?;
+    fs::write(
+        temp_path.join("test_dir").join("nested_file.txt"),
+        "nested content",
+    )?;
+
+    // 隠しファイルを作成
+    fs::write(temp_path.join(".hidden_file"), "hidden content")?;
+
+    Ok(temp_dir)
+}
+
+#[tokio::test]
+async fn test_list_directory_success() {
+    let temp_dir = create_test_structure().await.unwrap();
+    let manager = FileSystemManager::new();
+
+    let entries = manager.list_directory(temp_dir.path()).await.unwrap();
+
+    // 3つのエントリが存在することを確認（ファイル、ディレクトリ、隠しファイル）
+    assert_eq!(entries.len(), 3);
+
+    // ファイルタイプの確認
+    let file_entry = entries.iter().find(|e| e.name == "test_file.txt").unwrap();
+    assert_eq!(file_entry.file_type, FileType::File);
+    assert!(file_entry.size > 0);
+
+    let dir_entry = entries.iter().find(|e| e.name == "test_dir").unwrap();
+    assert_eq!(dir_entry.file_type, FileType::Directory);
+
+    let hidden_entry = entries.iter().find(|e| e.name == ".hidden_file").unwrap();
+    assert_eq!(hidden_entry.file_type, FileType::File);
+}
+
+#[tokio::test]
+async fn test_list_directory_invalid_path() {
+    let manager = FileSystemManager::new();
+    let invalid_path = PathBuf::from("/nonexistent/path");
+
+    let result = manager.list_directory(&invalid_path).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_list_directory_file_not_directory() {
+    let temp_dir = create_test_structure().await.unwrap();
+    let manager = FileSystemManager::new();
+    let file_path = temp_dir.path().join("test_file.txt");
+
+    let result = manager.list_directory(&file_path).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_get_file_info_success() {
+    let temp_dir = create_test_structure().await.unwrap();
+    let manager = FileSystemManager::new();
+    let file_path = temp_dir.path().join("test_file.txt");
+
+    let file_info = manager.get_file_info(&file_path).await.unwrap();
+
+    assert_eq!(file_info.path, file_path);
+    assert_eq!(file_info.file_type, FileType::File);
+    assert!(file_info.size > 0);
+    assert!(file_info.modified.is_some());
+}
+
+#[tokio::test]
+async fn test_get_file_info_directory() {
+    let temp_dir = create_test_structure().await.unwrap();
+    let manager = FileSystemManager::new();
+    let dir_path = temp_dir.path().join("test_dir");
+
+    let file_info = manager.get_file_info(&dir_path).await.unwrap();
+
+    assert_eq!(file_info.path, dir_path);
+    assert_eq!(file_info.file_type, FileType::Directory);
+    assert!(file_info.modified.is_some());
+}
+
+#[tokio::test]
+async fn test_get_file_info_invalid_path() {
+    let manager = FileSystemManager::new();
+    let invalid_path = PathBuf::from("/nonexistent/file.txt");
+
+    let result = manager.get_file_info(&invalid_path).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_is_accessible() {
+    let temp_dir = create_test_structure().await.unwrap();
+    let manager = FileSystemManager::new();
+
+    // 存在するファイルへのアクセス
+    let file_path = temp_dir.path().join("test_file.txt");
+    assert!(manager.is_accessible(&file_path));
+
+    // 存在するディレクトリへのアクセス
+    let dir_path = temp_dir.path().join("test_dir");
+    assert!(manager.is_accessible(&dir_path));
+
+    // 存在しないパスへのアクセス
+    let invalid_path = PathBuf::from("/nonexistent/path");
+    assert!(!manager.is_accessible(&invalid_path));
+}
+
+#[tokio::test]
+async fn test_directory_entries_sorted() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // 複数のファイルを作成（意図的に名前順でない順序で）
+    fs::write(temp_path.join("z_file.txt"), "content").unwrap();
+    fs::write(temp_path.join("a_file.txt"), "content").unwrap();
+    fs::write(temp_path.join("m_file.txt"), "content").unwrap();
+
+    let manager = FileSystemManager::new();
+    let entries = manager.list_directory(temp_path).await.unwrap();
+
+    // エントリが名前順でソートされていることを確認
+    let names: Vec<&String> = entries.iter().map(|e| &e.name).collect();
+    let mut sorted_names = names.clone();
+    sorted_names.sort();
+
+    assert_eq!(names, sorted_names);
+}
+
+#[tokio::test]
+async fn test_empty_directory() {
+    let temp_dir = TempDir::new().unwrap();
+    let manager = FileSystemManager::new();
+
+    let entries = manager.list_directory(temp_dir.path()).await.unwrap();
+    assert!(entries.is_empty());
+}
+
+#[tokio::test]
+async fn test_nested_directory_access() {
+    let temp_dir = create_test_structure().await.unwrap();
+    let manager = FileSystemManager::new();
+    let nested_dir = temp_dir.path().join("test_dir");
+
+    let entries = manager.list_directory(&nested_dir).await.unwrap();
+    assert_eq!(entries.len(), 1);
+
+    let nested_file = entries
+        .iter()
+        .find(|e| e.name == "nested_file.txt")
+        .unwrap();
+    assert_eq!(nested_file.file_type, FileType::File);
+}

--- a/crates/core/src/tests/mod.rs
+++ b/crates/core/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod filesystem_tests;

--- a/crates/utils/src/logging.rs
+++ b/crates/utils/src/logging.rs
@@ -5,7 +5,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
-use tracing::{info, warn, Level};
+use tracing::{Level, info, warn};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::EnvFilter;
 
@@ -206,7 +206,7 @@ impl PerformanceTimer {
     pub fn start(operation_name: impl Into<String>) -> Self {
         let operation_name = operation_name.into();
         info!(operation = %operation_name, "Starting operation");
-        
+
         Self {
             start_time: std::time::Instant::now(),
             operation_name,

--- a/crates/utils/src/panic_handler.rs
+++ b/crates/utils/src/panic_handler.rs
@@ -4,7 +4,9 @@
 
 #![allow(clippy::result_large_err)]
 
-use crate::error::{AppError, AppResultExt, ErrorCategory, ErrorMetadata, ErrorSeverity, error_utils};
+use crate::error::{
+    AppError, AppResultExt, ErrorCategory, ErrorMetadata, ErrorSeverity, error_utils,
+};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::backtrace::{Backtrace, BacktraceStatus};

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@
 
 use rust_explorer_ui::App;
 use rust_explorer_utils::{
-    AppResult, LogConfig, LogLevel, LogOutput, LogRotation, PanicHandlerConfig, PostPanicAction, 
-    init_logging, init_panic_handler, PerformanceTimer,
+    AppResult, LogConfig, LogLevel, LogOutput, LogRotation, PanicHandlerConfig, PerformanceTimer,
+    PostPanicAction, init_logging, init_panic_handler,
 };
 use std::path::PathBuf;
-use tracing::{info, error};
+use tracing::{error, info};
 
 fn main() -> AppResult<()> {
     // ログシステムの初期化


### PR DESCRIPTION
## Summary

Issue #12で要求された基本的なファイルシステム操作APIを実装しました。

### 実装内容

- **FileSystemApiトレイト**: ディレクトリ一覧取得、ファイル情報取得、アクセス可能性チェック
- **構造体定義**: FileEntry, FileInfo, FileType
- **非同期対応**: tokio::fsを使用した非同期ファイル操作
- **クロスプラットフォーム対応**: Windows/macOS/Linux互換
- **キャッシュ対応**: CachedFileSystemManager（将来の実装用）
- **包括的テスト**: 10個のテストケースで機能を検証

### API仕様

```rust
pub trait FileSystemApi {
    async fn list_directory(&self, path: &Path) -> Result<Vec<FileEntry>, AppError>;
    async fn get_file_info(&self, path: &Path) -> Result<FileInfo, AppError>;
    fn is_accessible(&self, path: &Path) -> bool;
}
```

### Test plan

- [x] ディレクトリ一覧取得の正常ケース
- [x] 無効なパスでのエラーハンドリング
- [x] ファイル情報取得の正常ケース
- [x] アクセス可能性チェック
- [x] ファイルエントリのソート確認
- [x] 空ディレクトリの処理
- [x] ネストされたディレクトリアクセス
- [x] すべてのテストが成功し、cargo fmtとcargo clippyも通過

🤖 Generated with [Claude Code](https://claude.ai/code)